### PR TITLE
pdf-roll: Support page change hooks

### DIFF
--- a/lisp/pdf-annot.el
+++ b/lisp/pdf-annot.el
@@ -998,7 +998,8 @@ other annotations."
                 `("white" "steel blue" 0.35 ,@edges))
              :map (pdf-view-apply-hotspot-functions
                    window page size)
-             :width (car size))))
+             :width (car size))
+           (when pdf-view-roll-minor-mode page)))
         (pdf-util-scroll-to-edges
          (pdf-util-scale-relative-to-pixel (car edges)))))))
 

--- a/lisp/pdf-isearch.el
+++ b/lisp/pdf-isearch.el
@@ -743,7 +743,8 @@ MATCH-BG LAZY-FG LAZY-BG\)."
                                  occur-hack-p)
                              (eq page (pdf-view-current-page)))
                     (pdf-view-display-image
-                     (pdf-view-create-image data :width width))))))))
+                     (pdf-view-create-image data :width width)
+                     (when pdf-view-roll-minor-mode page))))))))
       (pdf-info-renderpage-text-regions
        page width t nil
        `(,fg1 ,bg1 ,@(pdf-util-scale-pixel-to-relative

--- a/lisp/pdf-isearch.el
+++ b/lisp/pdf-isearch.el
@@ -278,7 +278,8 @@ This is a Isearch interface function."
         ;; Don't get off track.
         (when (or (and (bobp) (not isearch-forward))
                   (and (eobp) isearch-forward))
-          (goto-char (1+ (/ (buffer-size) 2))))
+          (unless pdf-view-roll-minor-mode
+            (goto-char (1+ (/ (buffer-size) 2)))))
         ;; Signal success to isearch.
         (if isearch-forward
             (re-search-forward ".")
@@ -347,7 +348,8 @@ This is a Isearch interface function."
         pdf-isearch-current-match nil
         pdf-isearch-current-matches nil
         pdf-isearch-current-parameter nil)
-  (goto-char (1+ (/ (buffer-size) 2))))
+  (unless pdf-view-roll-minor-mode
+    (goto-char (1+ (/ (buffer-size) 2)))))
 
 (defun pdf-isearch-same-search-p (&optional ignore-search-string-p)
   "Return non-nil, if search parameter have not changed.
@@ -742,6 +744,8 @@ MATCH-BG LAZY-FG LAZY-BG\)."
                              (or isearch-mode
                                  occur-hack-p)
                              (eq page (pdf-view-current-page)))
+                    (when pdf-view-roll-minor-mode
+                      (pdf-view-goto-page page))
                     (pdf-view-display-image
                      (pdf-view-create-image data :width width)
                      (when pdf-view-roll-minor-mode page))))))))

--- a/lisp/pdf-links.el
+++ b/lisp/pdf-links.el
@@ -209,16 +209,20 @@ scroll the current page."
            (when (derived-mode-p 'pdf-view-mode)
              (when (> .page 0)
                (pdf-view-goto-page .page))
-             (when .top
+             ;; TODO fix pdf-util-tooltip-arrow function for image-roll
+             ;; compatibility
+
+             ;;(when .top
                ;; Showing the tooltip delays displaying the page for
                ;; some reason (sit-for/redisplay don't help), do it
                ;; later.
-               (run-with-idle-timer 0.001 nil
-                 (lambda ()
-                   (when (window-live-p window)
-                     (with-selected-window window
-                       (when (derived-mode-p 'pdf-view-mode)
-                         (pdf-util-tooltip-arrow .top)))))))))))
+               ;;(run-with-idle-timer 0.001 nil
+                 ;;(lambda ()
+                   ;;(when (window-live-p window)
+                     ;;(with-selected-window window
+                       ;;(when (derived-mode-p 'pdf-view-mode)
+                         ;;(pdf-util-tooltip-arrow .top)))))))
+             ))))
       (uri
        (funcall pdf-links-browse-uri-function .uri))
       (t
@@ -266,7 +270,8 @@ See `pdf-links-action-perform' for the interface."
              (pdf-view-current-page)
              (car size) image-data 'pdf-links-read-link-action))
           (pdf-view-display-image
-           (create-image image-data (pdf-view-image-type) t))
+           (create-image image-data (pdf-view-image-type) t)
+           (when pdf-view-roll-minor-mode (pdf-view-current-page)))
           (pdf-links-read-link-action--read-chars prompt alist))
       (pdf-view-redisplay))))
 

--- a/lisp/pdf-roll.el
+++ b/lisp/pdf-roll.el
@@ -60,7 +60,10 @@ continuous scrolling."
          (let ((inhibit-read-only t))
            (erase-buffer)
            (image-roll-new-window-function (list (selected-window))))
-         (pdf-view-redisplay))
+         (pdf-view-redisplay)
+
+         (define-key pdf-view-mode-map (kbd "<mouse-5>") 'pdf-view-next-line-or-next-page)
+         (define-key pdf-view-mode-map (kbd "<mouse-4>") 'pdf-view-previous-line-or-previous-page))
         (t
          (remove-hook 'window-configuration-change-hook 'image-roll-redisplay t)
 
@@ -71,7 +74,9 @@ continuous scrolling."
            (erase-buffer)
            (insert-file-contents-literally (buffer-file-name))
            (pdf-view-new-window-function (list (selected-window)))
-           (set-buffer-modified-p nil)))))
+           (set-buffer-modified-p nil))
+         (define-key pdf-view-mode-map (kbd "<mouse-5>") 'mwheel-scroll)
+         (define-key pdf-view-mode-map (kbd "<mouse-4>") 'mwheel-scroll))))
 
 (provide 'pdf-roll)
 

--- a/lisp/pdf-roll.el
+++ b/lisp/pdf-roll.el
@@ -27,12 +27,12 @@
   (require 'pdf-view))
 
 
-(defun pdf-scroll-page-sizes ()
+(defun pdf-roll-page-sizes ()
   (let (s)
     (dotimes (i (pdf-info-number-of-pages) (nreverse s))
       (push (pdf-view-desired-image-size (1+ i)) s))))
 
-(defun pdf-scroll-set-redisplay-flag-function ()
+(defun pdf-roll-set-redisplay-flag-function ()
   (setf (pdf-view-window-needs-redisplay) t))
 
 (define-minor-mode pdf-view-roll-minor-mode
@@ -46,25 +46,25 @@ continuous scrolling."
   (cond (pdf-view-roll-minor-mode
          (setq-local image-roll-last-page (pdf-cache-number-of-pages)
                      image-roll-display-page-function 'pdf-view-display-page
-                     image-roll-page-sizes-function 'pdf-scroll-page-sizes
-                     image-roll-set-redisplay-flag-function 'pdf-scroll-set-redisplay-flag-function
+                     image-roll-page-sizes-function 'pdf-roll-page-sizes
+                     image-roll-set-redisplay-flag-function 'pdf-roll-set-redisplay-flag-function
 
                      image-roll-center t)
 
-         (add-hook 'window-configuration-change-hook 'image-roll--redisplay nil t)
+         (add-hook 'window-configuration-change-hook 'image-roll-redisplay nil t)
 
          (remove-hook 'image-mode-new-window-functions
 	                    #'pdf-view-new-window-function t)
-         (add-hook 'image-mode-new-window-functions 'image-roll--new-window-function nil t)
+         (add-hook 'image-mode-new-window-functions 'image-roll-new-window-function nil t)
 
          (let ((inhibit-read-only t))
            (erase-buffer)
-           (image-roll--new-window-function (list (selected-window))))
+           (image-roll-new-window-function (list (selected-window))))
          (pdf-view-redisplay))
         (t
-         (remove-hook 'window-configuration-change-hook 'image-roll--redisplay t)
+         (remove-hook 'window-configuration-change-hook 'image-roll-redisplay t)
 
-         (remove-hook 'image-mode-new-window-functions 'image-roll--new-window-function t)
+         (remove-hook 'image-mode-new-window-functions 'image-roll-new-window-function t)
          (add-hook 'image-mode-new-window-functions
 	                    #'pdf-view-new-window-function nil t)
          (let ((inhibit-read-only t))

--- a/lisp/pdf-roll.el
+++ b/lisp/pdf-roll.el
@@ -1,0 +1,78 @@
+;;; pdf-roll.el --- Add continuous scroll. -*- lexical-binding: t -*-
+
+;; Copyright (C) 2013, 2014  Andreas Politz
+
+;; Author: Daniel Nicolai <dalanicolai@gmail.com>
+;; Keywords: files, multimedia
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+
+(require 'image-roll)
+
+(eval-when-compile
+  (require 'pdf-view))
+
+
+(defun pdf-scroll-page-sizes ()
+  (let (s)
+    (dotimes (i (pdf-info-number-of-pages) (nreverse s))
+      (push (pdf-view-desired-image-size (1+ i)) s))))
+
+(defun pdf-scroll-set-redisplay-flag-function ()
+  (setf (pdf-view-window-needs-redisplay) t))
+
+(define-minor-mode pdf-view-roll-minor-mode
+  "If enabled display document on a virtual scroll providing
+continuous scrolling."
+  :lighter " Continuous"
+  :keymap `((,(kbd "S-<next>") . image-roll-scroll-screen-forward)
+            (,(kbd "S-<prior>") . image-roll-scroll-screen-backward))
+  :version 28.1
+
+  (cond (pdf-view-roll-minor-mode
+         (setq-local image-roll-last-page (pdf-cache-number-of-pages)
+                     image-roll-display-page-function 'pdf-view-display-page
+                     image-roll-page-sizes-function 'pdf-scroll-page-sizes
+                     image-roll-set-redisplay-flag-function 'pdf-scroll-set-redisplay-flag-function
+
+                     image-roll-center t)
+
+         (add-hook 'window-configuration-change-hook 'image-roll--redisplay nil t)
+
+         (remove-hook 'image-mode-new-window-functions
+	                    #'pdf-view-new-window-function t)
+         (add-hook 'image-mode-new-window-functions 'image-roll--new-window-function nil t)
+
+         (let ((inhibit-read-only t))
+           (erase-buffer)
+           (image-roll--new-window-function (list (selected-window))))
+         (pdf-view-redisplay))
+        (t
+         (remove-hook 'window-configuration-change-hook 'image-roll--redisplay t)
+
+         (remove-hook 'image-mode-new-window-functions 'image-roll--new-window-function t)
+         (add-hook 'image-mode-new-window-functions
+	                    #'pdf-view-new-window-function nil t)
+         (let ((inhibit-read-only t))
+           (erase-buffer)
+           (insert-file-contents-literally (buffer-file-name))
+           (pdf-view-new-window-function (list (selected-window)))
+           (set-buffer-modified-p nil)))))
+
+(provide 'pdf-roll)
+
+;;; pdf-roll.el ends here

--- a/lisp/pdf-roll.el
+++ b/lisp/pdf-roll.el
@@ -49,7 +49,10 @@ continuous scrolling."
                      image-roll-page-sizes-function 'pdf-roll-page-sizes
                      image-roll-set-redisplay-flag-function 'pdf-roll-set-redisplay-flag-function
 
-                     image-roll-center t)
+                     image-roll-center t
+                     image-roll-change-page-hook pdf-view-change-page-hook
+                     image-roll-before-change-page-hook pdf-view-before-change-page-hook
+                     image-roll-after-change-page-hook pdf-view-after-change-page-hook)
 
          (add-hook 'window-configuration-change-hook 'image-roll-redisplay nil t)
 

--- a/lisp/pdf-sync.el
+++ b/lisp/pdf-sync.el
@@ -645,6 +645,7 @@ Needs to have `pdf-sync-backward-debug-minor-mode' enabled."
 ;; * Forward search (TeX -> PDF)
 ;; * ================================================================== *
 
+;; TODO adapt for `pdf-view-roll-minor-mode' (see pdf-scroll.el)
 (defun pdf-sync-forward-search (&optional line column)
   "Display the PDF location corresponding to LINE, COLUMN."
   (interactive)

--- a/lisp/pdf-tools.el
+++ b/lisp/pdf-tools.el
@@ -94,6 +94,7 @@
 (require 'pdf-view)
 (require 'pdf-util)
 (require 'pdf-info)
+(require 'pdf-roll)
 (require 'cus-edit)
 (require 'compile)
 (require 'cl-lib)

--- a/lisp/pdf-util.el
+++ b/lisp/pdf-util.el
@@ -432,7 +432,8 @@ needed."
   (unless context-pixel
     (setq context-pixel 0))
   (let* ((win (window-inside-pixel-edges))
-         (image-width (car (pdf-view-image-size t)))
+         (image-width (car (pdf-view-image-size (unless pdf-view-roll-minor-mode
+                                                  t))))
          (image-left (* (frame-char-width)
                         (window-hscroll)))
          (edges (pdf-util-translate
@@ -472,7 +473,9 @@ Note: For versions of emacs before 27 this will return lines instead of
 pixels. This is because of a change that occurred to `image-mode' in 27."
   (pdf-util-assert-pdf-window)
   (let* ((win (window-inside-pixel-edges))
-         (image-height (cdr (pdf-view-image-size t)))
+         (image-height (cdr (pdf-view-image-size
+                             (unless pdf-view-roll-minor-mode
+                               t))))
          (image-top (window-vscroll nil t))
          (edges (pdf-util-translate
                  edges

--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -625,8 +625,10 @@ windows."
 
 Optional parameter N moves N pages forward."
   (interactive "p")
-  (pdf-view-goto-page (+ (pdf-view-current-page)
-                         (or n 1))))
+  (if pdf-view-roll-minor-mode
+      (image-roll-next-page n)
+    (pdf-view-goto-page (+ (pdf-view-current-page)
+                           (or n 1)))))
 
 (defun pdf-view-previous-page (&optional n)
   "View the previous page in the PDF.

--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -1074,7 +1074,7 @@ If WINDOW is t, redisplay pages in all windows."
 
 (defun pdf-view-redisplay (&optional window)
   (if pdf-view-roll-minor-mode
-      (image-roll--redisplay window)
+      (image-roll-redisplay window)
     (pdf-view--redisplay window)))
 
 (defun pdf-view-redisplay-pages (&rest pages)

--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -756,7 +756,7 @@ at the bottom edge of the page moves to the next page."
 (defun pdf-view-next-line-or-next-page (&optional arg)
   (interactive "p")
   (if pdf-view-roll-minor-mode
-      (image-roll-scroll-forward)
+      (dotimes (_ (or arg 1)) (image-roll-scroll-forward))
     (pdf-view--next-line-or-next-page arg)))
 
 (defun pdf-view--previous-line-or-previous-page (&optional arg)
@@ -780,7 +780,7 @@ at the top edge of the page moves to the previous page."
 (defun pdf-view-previous-line-or-previous-page (&optional arg)
   (interactive "p")
   (if pdf-view-roll-minor-mode
-      (image-roll-scroll-backward)
+      (dotimes (_ (or arg 1)) (image-roll-scroll-backward))
     (pdf-view--previous-line-or-previous-page arg)))
 
 (defun pdf-view-goto-label (label)

--- a/lisp/pdf-view.el
+++ b/lisp/pdf-view.el
@@ -33,6 +33,9 @@
 (require 'bookmark)
 (require 'password-cache)
 
+(eval-when-compile
+  (require 'image-roll))
+
 (declare-function cua-copy-region "cua-base")
 (declare-function pdf-tools-pdf-buffer-p "pdf-tools")
 
@@ -730,7 +733,7 @@ to previous page only on typing DEL (ARG is nil)."
           (image-set-window-hscroll hscroll)))
     (image-scroll-down arg)))
 
-(defun pdf-view-next-line-or-next-page (&optional arg)
+(defun pdf-view--next-line-or-next-page (&optional arg)
   "Scroll upward by ARG lines if possible, else go to the next page.
 
 When `pdf-view-continuous' is non-nil, scrolling a line upward
@@ -748,7 +751,13 @@ at the bottom edge of the page moves to the next page."
           (image-set-window-hscroll hscroll)))
     (image-next-line 1)))
 
-(defun pdf-view-previous-line-or-previous-page (&optional arg)
+(defun pdf-view-next-line-or-next-page (&optional arg)
+  (interactive "p")
+  (if pdf-view-roll-minor-mode
+      (image-roll-scroll-forward)
+    (pdf-view--next-line-or-next-page arg)))
+
+(defun pdf-view--previous-line-or-previous-page (&optional arg)
   "Scroll downward by ARG lines if possible, else go to the previous page.
 
 When `pdf-view-continuous' is non-nil, scrolling a line downward
@@ -765,6 +774,12 @@ at the top edge of the page moves to the previous page."
             (image-bol 1))
           (image-set-window-hscroll hscroll)))
     (image-previous-line arg)))
+
+(defun pdf-view-previous-line-or-previous-page (&optional arg)
+  (interactive "p")
+  (if pdf-view-roll-minor-mode
+      (image-roll-scroll-backward)
+    (pdf-view--previous-line-or-previous-page arg)))
 
 (defun pdf-view-goto-label (label)
   "Go to the page corresponding to LABEL.
@@ -954,6 +969,9 @@ See also `pdf-view-use-imagemagick'."
          (hotspots (pdf-view-apply-hotspot-functions
                     window page size)))
     (pdf-view-create-image data
+      :margin (cons 0 (if pdf-view-roll-minor-mode
+                          image-roll-vertical-margin
+                        0))
       :width (car size)
       :map hotspots
       :pointer 'arrow)))
@@ -989,11 +1007,14 @@ It is equal to \(LEFT . TOP\) of the current slice in pixel."
   (setf (pdf-view-window-needs-redisplay window) nil)
   (pdf-view-display-image
    (pdf-view-create-page page window)
+   (when pdf-view-roll-minor-mode page)
    window))
 
-(defun pdf-view-display-image (image &optional window inhibit-slice-p)
+(defun pdf-view-display-image (image page &optional window inhibit-slice-p)
   ;; TODO: write documentation!
-  (let ((ol (pdf-view-current-overlay window)))
+  (let ((ol (if pdf-view-roll-minor-mode
+                (image-roll-page-overlay page)
+              (pdf-view-current-overlay window))))
     (when (window-live-p (overlay-get ol 'window))
       (let* ((size (image-size image t))
              (slice (if (not inhibit-slice-p)
@@ -1004,7 +1025,8 @@ It is equal to \(LEFT . TOP\) of the current slice in pixel."
                                       (car (image-size image)))
                                  (car (image-size image))))))
         (setf (pdf-view-current-image window) image)
-        (move-overlay ol (point-min) (point-max))
+        (unless pdf-view-roll-minor-mode
+          (move-overlay ol (point-min) (point-max)))
         ;; In case the window is wider than the image, center the image
         ;; horizontally.
         (overlay-put ol 'before-string
@@ -1020,15 +1042,16 @@ It is equal to \(LEFT . TOP\) of the current slice in pixel."
                                      (pdf-util-scale slice size 'round))
                                image)
                        image))
-        (let* ((win (overlay-get ol 'window))
-               (hscroll (image-mode-window-get 'hscroll win))
-               (vscroll (image-mode-window-get 'vscroll win)))
-          ;; Reset scroll settings, in case they were changed.
-          (if hscroll (set-window-hscroll win hscroll))
-          (if vscroll (set-window-vscroll
-                       win vscroll pdf-view-have-image-mode-pixel-vscroll)))))))
+        (unless pdf-view-roll-minor-mode
+          (let* ((win (overlay-get ol 'window))
+                 (hscroll (image-mode-window-get 'hscroll win))
+                 (vscroll (image-mode-window-get 'vscroll win)))
+            ;; Reset scroll settings, in case they were changed.
+            (if hscroll (set-window-hscroll win hscroll))
+            (if vscroll (set-window-vscroll
+                         win vscroll pdf-view-have-image-mode-pixel-vscroll))))))))
 
-(defun pdf-view-redisplay (&optional window)
+(defun pdf-view--redisplay (&optional window)
   "Redisplay page in WINDOW.
 
 If WINDOW is t, redisplay pages in all windows."
@@ -1048,6 +1071,11 @@ If WINDOW is t, redisplay pages in all windows."
                           (window-buffer window)))
             (setf (pdf-view-window-needs-redisplay window) t)))))
     (force-mode-line-update)))
+
+(defun pdf-view-redisplay (&optional window)
+  (if pdf-view-roll-minor-mode
+      (image-roll--redisplay window)
+    (pdf-view--redisplay window)))
 
 (defun pdf-view-redisplay-pages (&rest pages)
   "Redisplay PAGES in all windows."
@@ -1453,7 +1481,8 @@ This is more useful for commands like
            (pdf-info-renderpage-text-regions
             page width nil nil
             `(,(car colors) ,(cdr colors) ,@region)))
-       :width width))))
+       :width width)
+     (when pdf-view-roll-minor-mode page))))
 
 (defun pdf-view-kill-ring-save ()
   "Copy the region to the `kill-ring'."


### PR DESCRIPTION
* lisp/pdf-roll.el (pdf-view-roll-minor-mode): Transfer the pdf-view hooks to image-roll.

After merging the required hook functionality to image-roll, the corresponding pdf-tools hooks can be used with pdf-roll-mode.

Fixes #4.